### PR TITLE
added "addlevel" parameter and element option "none"

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -197,9 +197,15 @@ class Extension {
 			'range' => array( 1, 500 ),
 		);
 
+		$params['addlevel'] = array(
+			'type' => 'integer',
+			'default' => 0,
+			'range' => array( 0, 10 ),
+		);
+		
 		$params['element'] = array(
 			'default' => 'div',
-			'aliases' => array( 'div', 'p', 'span' ),
+			'aliases' => array( 'div', 'p', 'span', 'none' ),
 		);
 
 		$params['class'] = array(

--- a/src/Lister/UI/TreeListRenderer.php
+++ b/src/Lister/UI/TreeListRenderer.php
@@ -17,6 +17,7 @@ class TreeListRenderer extends HierarchyRenderingBehaviour {
 	const OPT_SHOW_TOP_PAGE = 'topPage';
 	const OPT_FORMAT = 'format';
 	const OPT_MAX_DEPTH = 'maxIndent';
+	const OPT_ADDLEVEL = 'addlevel';
 
 	const FORMAT_OL = 'ol';
 	const FORMAT_UL = 'ul';
@@ -35,6 +36,7 @@ class TreeListRenderer extends HierarchyRenderingBehaviour {
 				self::OPT_SHOW_TOP_PAGE => true,
 				self::OPT_FORMAT => self::FORMAT_UL,
 				self::OPT_MAX_DEPTH => self::NO_LIMIT,
+				self::OPT_ADDLEVEL => 0,
 			),
 			$options
 		);
@@ -97,7 +99,7 @@ class TreeListRenderer extends HierarchyRenderingBehaviour {
 	private function getIndentedLine( $lineContent, $indentationLevel ) {
 		if ( $indentationLevel > 0 ) {
 			$char = $this->getIndentCharacter();
-			$lineContent = str_repeat( $char, $indentationLevel ) . ' ' . $lineContent;
+			$lineContent = str_repeat( $char, $indentationLevel + ($this->options[self::OPT_ADDLEVEL])) . ' ' . $lineContent;
 		}
 
 		return $lineContent;

--- a/src/Lister/UI/WikitextSubPageListRenderer.php
+++ b/src/Lister/UI/WikitextSubPageListRenderer.php
@@ -65,6 +65,8 @@ class WikitextSubPageListRenderer implements SubPageListRenderer {
 		$options = array(
 			TreeListRenderer::OPT_SHOW_TOP_PAGE => $this->options['showpage'],
 		);
+		
+		$options[TreeListRenderer::OPT_ADDLEVEL] = $this->options['addlevel'];
 
 		if ( $this->options['kidsonly'] ) {
 			$options[TreeListRenderer::OPT_MAX_DEPTH] = 1;
@@ -119,20 +121,24 @@ class WikitextSubPageListRenderer implements SubPageListRenderer {
 	private function wrapInElement( $text ) {
 		$this->assertElementIsAllowed();
 
-		return Html::element(
-			$this->options['element'],
-			array(
-				'class' => $this->options['class']
-			),
-			"\n" . $text . "\n"
-		);
+		if ($this->options['element']!='none')
+		{
+			return Html::element(
+				$this->options['element'],
+				array(
+					'class' => $this->options['class']
+				),
+				"\n" . $text . "\n"
+			);
+		} else return $text;
 	}
 
 	private function assertElementIsAllowed() {
 		$allowedElements = array(
 			'p',
 			'div',
-			'span'
+			'span',
+			'none'
 		);
 
 		if ( !in_array( $this->options['element'], $allowedElements ) ) {


### PR DESCRIPTION
Adds ability to add a level to the hierarchy so SPL can begin listing inside of an existing hierarchy.

Adds element option "none" so returned text can be raw wikitext to be parsed by another parser function.