### PR TITLE
Fix implementation of kidsonly and showpage parameters

### DIFF
--- a/src/Lister/SubPageList.php
+++ b/src/Lister/SubPageList.php
@@ -78,21 +78,20 @@ class SubPageList implements HookHandler {
 	 * @return string
 	 */
 	private function renderForTitle( Title $title, array $parameters ) {
-		$topLevelPage = $this->getPageHierarchy( $title, $parameters['limit'] );
+		$topLevelPages = $this->getPageHierarchy( $title, $parameters['limit'] );
 
-		if ( $this->shouldUseDefault( $topLevelPage, $parameters['showpage'] ) ) {
+		if ( empty( $topLevelPages ) ) {
 			return $this->getDefault( $parameters['page'], $parameters['default'] );
 		}
-		else {
-			return $this->getRenderedList( $topLevelPage, $parameters );
-		}
+
+		return $this->getRenderedList( $topLevelPages, $parameters );
 	}
 
 	/**
 	 * @param Title $title
 	 * @param int $limit
 	 *
-	 * @return Page
+	 * @return Page[]
 	 * @throws LogicException
 	 */
 	private function getPageHierarchy( Title $title, $limit ) {
@@ -107,19 +106,12 @@ class SubPageList implements HookHandler {
 			throw new LogicException( 'Expected exactly one top level page' );
 		}
 
-		$topLevelPage = reset( $pageHierarchy );
-		return $topLevelPage;
+		return $pageHierarchy;
 	}
 
-	private function shouldUseDefault( Page $topLevelPage, $showTopLevelPage ) {
-		// Note: this behaviour is not fully correct.
-		// Other parameters that omit results need to be held into account as well.
-		return !$showTopLevelPage && $topLevelPage->getSubPages() === array();
-	}
-
-	private function getRenderedList( Page $topLevelPage, $parameters ) {
+	private function getRenderedList( array $topLevelPages, $parameters ) {
 		return $this->subPageListRenderer->render(
-			$topLevelPage,
+			$topLevelPages,
 			$parameters
 		);
 	}

--- a/src/Lister/UI/HierarchyRenderer.php
+++ b/src/Lister/UI/HierarchyRenderer.php
@@ -13,12 +13,12 @@ use SubPageList\Lister\Page;
 abstract class HierarchyRenderer {
 
 	/**
-	 * Render a page and its sub pages.
+	 * Render a list of top level pages and their sub pages.
 	 *
-	 * @param Page $page
+	 * @param Page[] $pages
 	 *
 	 * @return string
 	 */
-	public abstract function renderHierarchy( Page $page );
+	public abstract function renderHierarchy( array $pages );
 
 }

--- a/src/Lister/UI/HierarchyRendererFactory.php
+++ b/src/Lister/UI/HierarchyRendererFactory.php
@@ -21,22 +21,10 @@ class HierarchyRendererFactory {
 	 * @return HierarchyRenderer
 	 */
 	public function newTreeListRenderer( array $options ) {
-		$treeListOptions = array(
-			TreeListRenderer::OPT_SHOW_TOP_PAGE => $options['showpage'],
-		);
-
-		if ( $options['kidsonly'] ) {
-			$treeListOptions[TreeListRenderer::OPT_MAX_DEPTH] = 1;
-		}
-
-		if ( $options['format'] === 'ol' ) {
-			$treeListOptions[TreeListRenderer::OPT_FORMAT] = TreeListRenderer::FORMAT_OL;
-		}
-
 		return new TreeListRenderer(
 			$this->newPageRenderer( $options ),
 			$this->newPageSorter( $options['sort'] ),
-			$treeListOptions
+			$options['format'] === 'ol' ? TreeListRenderer::FORMAT_OL : TreeListRenderer::FORMAT_UL
 		);
 	}
 

--- a/src/Lister/UI/SubPageListRenderer.php
+++ b/src/Lister/UI/SubPageListRenderer.php
@@ -13,9 +13,8 @@ use SubPageList\Lister\Page;
 interface SubPageListRenderer {
 
 	/**
-	 * Render a representation of the page and its sub pages.
+	 * Render a representation of the pages and their sub pages.
 	 *
-	 * This might or might not include the top level page.
 	 * This might or might not include additional things
 	 * such as headers and footers.
 	 *
@@ -24,11 +23,11 @@ interface SubPageListRenderer {
 	 * The interface does not define which options can be,
 	 * or should be, supported by the implementing class.
 	 *
-	 * @param Page $page
+	 * @param Page[] $pages
 	 * @param array $options
 	 *
 	 * @return string
 	 */
-	public function render( Page $page, array $options );
+	public function render( array $pages, array $options );
 
 }

--- a/src/Lister/UI/WikitextSubPageListRenderer.php
+++ b/src/Lister/UI/WikitextSubPageListRenderer.php
@@ -29,17 +29,17 @@ class WikitextSubPageListRenderer implements SubPageListRenderer {
 	/**
 	 * @see SubPageListRenderer::render
 	 *
-	 * @param Page $page
+	 * @param Page[] $pages
 	 * @param array $options
 	 *
 	 * @return string
 	 */
-	public function render( Page $page, array $options ) {
+	public function render( array $pages, array $options ) {
 		$this->options = $options;
 		$this->text = '';
 
 		$this->addHeader();
-		$this->addPageHierarchy( $page );
+		$this->addPageHierarchy( $pages );
 		$this->addFooter();
 
 		return $this->wrapInElement( $this->text );
@@ -57,8 +57,8 @@ class WikitextSubPageListRenderer implements SubPageListRenderer {
 		}
 	}
 
-	private function addPageHierarchy( Page $page ) {
-		$this->text .= $this->hierarchyRendererFactory->newTreeListRenderer( $this->options )->renderHierarchy( $page );
+	private function addPageHierarchy( array $pages ) {
+		$this->text .= $this->hierarchyRendererFactory->newTreeListRenderer( $this->options )->renderHierarchy( $pages );
 	}
 
 	private function wrapInElement( $text ) {

--- a/tests/Component/WikitextSubPageListRendererTest.php
+++ b/tests/Component/WikitextSubPageListRendererTest.php
@@ -60,7 +60,7 @@ class WikitextSubPageListRendererTest extends \PHPUnit_Framework_TestCase {
 		$params = $this->getProcessedParams( $definition, $rawParams );
 
 		return $extension->newSubPageListRenderer()->render(
-			self::$pages[$params['page']],
+			array( self::$pages[$params['page']] ),
 			$params
 		);
 	}
@@ -86,7 +86,6 @@ class WikitextSubPageListRendererTest extends \PHPUnit_Framework_TestCase {
 		$this->assertCreatesList(
 			array(
 				'page' => 'AAA',
-				'showpage' => 'yes',
 			),
 			'<div class="subpagelist">' . "\n[[AAA|AAA]]\n</div>"
 		);
@@ -96,7 +95,6 @@ class WikitextSubPageListRendererTest extends \PHPUnit_Framework_TestCase {
 		$this->assertCreatesList(
 			array(
 				'page' => 'BBB',
-				'showpage' => 'yes',
 			),
 			'<div class="subpagelist">
 [[BBB|BBB]]
@@ -113,7 +111,6 @@ class WikitextSubPageListRendererTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'page' => 'AAA',
 				'intro' => $introText,
-				'showpage' => 'yes',
 			),
 			'<div class="subpagelist">' . "\n" .$introText . "\n[[AAA|AAA]]\n</div>"
 		);
@@ -135,7 +132,6 @@ class WikitextSubPageListRendererTest extends \PHPUnit_Framework_TestCase {
 			array(
 				'page' => 'AAA',
 				'outro' => $outroText,
-				'showpage' => 'yes',
 			),
 			'<div class="subpagelist">' ."\n[[AAA|AAA]]\n" . $outroText . "\n</div>"
 		);
@@ -147,7 +143,7 @@ class WikitextSubPageListRendererTest extends \PHPUnit_Framework_TestCase {
 				'page' => 'BBB',
 				'links' => 'no',
 			),
-			'<div class="subpagelist">' ."\n* Sub\n</div>"
+			'<div class="subpagelist">' ."\nBBB\n* Sub\n</div>"
 		);
 	}
 
@@ -155,7 +151,6 @@ class WikitextSubPageListRendererTest extends \PHPUnit_Framework_TestCase {
 		$this->assertCreatesList(
 			array(
 				'page' => 'BBB',
-				'showpage' => 'yes',
 				'format' => 'ol',
 			),
 			'<div class="subpagelist">
@@ -169,7 +164,6 @@ class WikitextSubPageListRendererTest extends \PHPUnit_Framework_TestCase {
 		$this->assertCreatesList(
 			array(
 				'page' => 'BBB',
-				'showpage' => 'yes',
 				'format' => 'ol',
 				'template' => 'foo',
 			),

--- a/tests/Unit/SubPageList/Lister/PageHierarchyCreatorTest.php
+++ b/tests/Unit/SubPageList/Lister/PageHierarchyCreatorTest.php
@@ -201,17 +201,22 @@ class PageHierarchyCreatorTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testMultipleChildrenForSameTopLevelPage() {
-		$pages[] = $this->newMockTitle( 'SomePage/Child0/GrandChild00' );
+		$titles[] = $this->newMockTitle( 'SomePage/Child0/GrandChild00' );
 
-		$pages[] = $this->newMockTitle( 'SomePage/Child1/GrandChild10' );
-		$pages[] = $this->newMockTitle( 'SomePage/Child1/GrandChild11' );
+		$grandChild10 = $this->newMockTitle( 'SomePage/Child1/GrandChild10' );
+		$grandChild11 = $this->newMockTitle( 'SomePage/Child1/GrandChild11' );
+		$grandChild20 = $this->newMockTitle( 'SomePage/Child2/GrandChild20' );
+		$grandChild21 = $this->newMockTitle( 'SomePage/Child2/GrandChild21' );
 
-		$pages[] = $this->newMockTitle( 'SomePage/Child2/GrandChild20' );
-		$pages[] = $this->newMockTitle( 'SomePage/Child2' );
-		$pages[] = $this->newMockTitle( 'SomePage/Child2/GrandChild21' );
+		$titles[] = $grandChild10;
+		$titles[] = $grandChild11;
+
+		$titles[] = $grandChild20;
+		$titles[] = $this->newMockTitle( 'SomePage/Child2' );
+		$titles[] = $grandChild21;
 
 		$hierarchyCreator = $this->newPageHierarchyCreator();
-		$hierarchy = $hierarchyCreator->createHierarchy( $pages );
+		$hierarchy = $hierarchyCreator->createHierarchy( $titles );
 
 		$this->assertEquals(
 			array(
@@ -230,10 +235,10 @@ class PageHierarchyCreatorTest extends \PHPUnit_Framework_TestCase {
 							$this->newMockTitle( 'SomePage/Child1' ),
 							array(
 								new Page(
-									$this->newMockTitle( 'SomePage/Child0/GrandChild10' )
+									$grandChild10
 								),
 								new Page(
-									$this->newMockTitle( 'SomePage/Child0/GrandChild11' )
+									$grandChild11
 								)
 							)
 						),
@@ -241,10 +246,10 @@ class PageHierarchyCreatorTest extends \PHPUnit_Framework_TestCase {
 							$this->newMockTitle( 'SomePage/Child2' ),
 							array(
 								new Page(
-									$this->newMockTitle( 'SomePage/Child0/GrandChild20' )
+									$grandChild20
 								),
 								new Page(
-									$this->newMockTitle( 'SomePage/Child0/GrandChild21' )
+									$grandChild21
 								)
 							)
 						)

--- a/tests/Unit/SubPageList/Lister/PageTest.php
+++ b/tests/Unit/SubPageList/Lister/PageTest.php
@@ -14,17 +14,33 @@ use SubPageList\Lister\Page;
  */
 class PageTest extends \PHPUnit_Framework_TestCase {
 
-	public function testConstructSetsFields() {
+	public function testConstructorSetsFields() {
 		$title = $this->getMock( 'Title' );
 		$children = array(
 			new Page( $this->getMock( 'Title' ) ),
-			new Page( $this->getMock( 'Title' ) )
 		);
 
 		$page = new Page( $title, $children );
 
 		$this->assertEquals( $title, $page->getTitle() );
 		$this->assertEquals( $children, $page->getSubPages() );
+	}
+
+	public function testDuplicatesAreOmitted() {
+		$sub0 = new Page( \Title::newFromText( 'sub0' ), array() );
+		$sub1 = new Page( \Title::newFromText( 'sub1' ), array() );
+
+		$page = new Page( $this->getMock( 'Title' ), array() );
+		$page->addSubPage( $sub0 );
+		$page->addSubPage( $sub1 );
+
+		$this->assertSame(
+			array(
+				$sub0,
+				$sub1
+			),
+			$page->getSubPages()
+		);
 	}
 
 }

--- a/tests/Unit/SubPageList/Lister/SubPageListTest.php
+++ b/tests/Unit/SubPageList/Lister/SubPageListTest.php
@@ -53,7 +53,7 @@ class SubPageListTest extends \PHPUnit_Framework_TestCase {
 
 		$renderer->expects( $this->once() )
 			->method( 'render' )
-			->with( $this->equalTo( $page ) )
+			->with( $this->equalTo( array( $page ) ) )
 			->will( $this->returnValue( $renderResult ) );
 
 		return new SubPageList(

--- a/tests/Unit/SubPageList/Lister/UI/TreeListRendererTest.php
+++ b/tests/Unit/SubPageList/Lister/UI/TreeListRendererTest.php
@@ -23,10 +23,7 @@ class TreeListRendererTest extends \PHPUnit_Framework_TestCase {
 	public function testRenderHierarchyWithNoSubPages( $titleText ) {
 		$this->assertRendersHierarchy(
 			new Page( Title::newFromText( $titleText ) ),
-			'',
-			array(
-				TreeListRenderer::OPT_SHOW_TOP_PAGE => false
-			)
+			$titleText
 		);
 	}
 
@@ -48,10 +45,10 @@ class TreeListRendererTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	private function assertRendersHierarchy( Page $page, $expected, array $options = array() ) {
+	private function assertRendersHierarchy( $pageOrPages, $expected, array $options = array() ) {
 		$listRender = $this->newListRenderer( $options );
 
-		$actual = $listRender->renderHierarchy( $page );
+		$actual = $listRender->renderHierarchy( is_array( $pageOrPages ) ? $pageOrPages : array( $pageOrPages ) );
 
 		$this->assertEquals( $expected, $actual );
 	}
@@ -70,7 +67,7 @@ class TreeListRendererTest extends \PHPUnit_Framework_TestCase {
 		 return new TreeListRenderer(
 			 $pageRenderer,
 			 new AlphabeticPageSorter( $sort ),
-			 $options
+			 array_key_exists( 'format', $options ) ? $options['format'] : TreeListRenderer::FORMAT_UL
 		 );
 	}
 
@@ -120,7 +117,7 @@ class TreeListRendererTest extends \PHPUnit_Framework_TestCase {
 # BBB
 # CCC',
 			array(
-				TreeListRenderer::OPT_FORMAT => TreeListRenderer::FORMAT_OL
+				'format' => TreeListRenderer::FORMAT_OL
 			)
 		);
 	}
@@ -159,37 +156,31 @@ class TreeListRendererTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testRenderHierarchyWithDepthLimit() {
+	public function testRenderMultipleTopLevelPages() {
 		$this->assertRendersHierarchy(
-			new Page(
-				Title::newFromText( 'AAA' ),
-				array(
-					new Page(
-						Title::newFromText( 'BBB' ),
-						array(
-							new Page( Title::newFromText( '111' ) ),
-							new Page( Title::newFromText( '222' ) ),
+			array(
+				new Page(
+					Title::newFromText( 'AAA' ),
+					array()
+				),
+				new Page(
+					Title::newFromText( 'BBB' ),
+					array(
+						new Page(
+							Title::newFromText( 'Sub' ),
+							array()
 						)
-					),
-					new Page(
-						Title::newFromText( 'CCC' ),
-						array()
-					),
-					new Page(
-						Title::newFromText( 'DDD' ),
-						array(
-							new Page( Title::newFromText( '333' ) ),
-						)
-					),
+					)
+				),
+				new Page(
+					Title::newFromText( 'CCC' ),
+					array()
 				)
 			),
-			'AAA
+			'* AAA
 * BBB
-* CCC
-* DDD',
-			array(
-				TreeListRenderer::OPT_MAX_DEPTH => 1
-			)
+** Sub
+* CCC'
 		);
 	}
 


### PR DESCRIPTION
This is a work in progress - so far the wrong implementation has been removed. This means there are some failing system tests. A new implementation, including new unit tests, needs to be added before this can be merged. Such a new implementation needs to be outside of the UI classes such as `WikitextSubPageListRenderer`, so these classes can focus on visualizing the already correctly filtered data structure. `PageHierarchyCreator` is a candidate to house the relevant code, though perhaps adding it in there makes it overly complex. Splitting this class up, or perhaps putting this kind of logic into the Page class itself might be better.