### PR TITLE
New parameter "addlevel"

### DIFF
--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -113,6 +113,20 @@ Allows specifying a MediaWiki template to format the page names with. The templa
 single unnamed parameter which is the page name. The format of the page name depends on the
 <code>pathstyle</code> parameter.
 
+#### Increase level/indent
+
+Parameter name: addlevel
+
+Allows user to specify an integer number of levels (up to 10) to add to bullets/numbers 
+so resulting list can be appended to another list outside.  
+
+Example output for <code>addlevel=2</code>:
+    *** Parent
+		**** Child 1
+		**** Child 2
+
+Default: 0
+
 #### Wrapping HTML element
 
 Parameter name: element

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -197,6 +197,12 @@ class Extension {
 			'range' => array( 1, 500 ),
 		);
 
+		$params['addlevel'] = array(
+			'type' => 'integer',
+			'default' => 0,
+			'range' => array( 0, 10 ),
+		);
+		
 		$params['element'] = array(
 			'default' => 'div',
 			'aliases' => array( 'div', 'p', 'span' ),

--- a/src/Lister/UI/TreeListRenderer.php
+++ b/src/Lister/UI/TreeListRenderer.php
@@ -7,7 +7,7 @@ use SubPageList\Lister\PageSorter;
 use SubPageList\Lister\UI\PageRenderer\PageRenderer;
 
 /**
- * @since 1.2
+ * @since 1.0
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
@@ -17,6 +17,7 @@ class TreeListRenderer extends HierarchyRenderer {
 	const OPT_SHOW_TOP_PAGE = 'topPage';
 	const OPT_FORMAT = 'format';
 	const OPT_MAX_DEPTH = 'maxIndent';
+	const OPT_ADDLEVEL = 'addlevel';
 
 	const FORMAT_OL = 'ol';
 	const FORMAT_UL = 'ul';
@@ -35,6 +36,7 @@ class TreeListRenderer extends HierarchyRenderer {
 				self::OPT_SHOW_TOP_PAGE => true,
 				self::OPT_FORMAT => self::FORMAT_UL,
 				self::OPT_MAX_DEPTH => self::NO_LIMIT,
+				self::OPT_ADDLEVEL => 0,
 			),
 			$options
 		);
@@ -97,7 +99,7 @@ class TreeListRenderer extends HierarchyRenderer {
 	private function getIndentedLine( $lineContent, $indentationLevel ) {
 		if ( $indentationLevel > 0 ) {
 			$char = $this->getIndentCharacter();
-			$lineContent = str_repeat( $char, $indentationLevel ) . ' ' . $lineContent;
+			$lineContent = str_repeat( $char, $indentationLevel + ($this->options[self::OPT_ADDLEVEL])) . ' ' . $lineContent;
 		}
 
 		return $lineContent;

--- a/tests/Component/WikitextSubPageListRendererTest.php
+++ b/tests/Component/WikitextSubPageListRendererTest.php
@@ -190,5 +190,17 @@ class WikitextSubPageListRendererTest extends \PHPUnit_Framework_TestCase {
 			'element'=> $badElement,
 		) );
 	}
+	
+		public function testListForOnePageWithOneSub() {
+		$this->assertCreatesList(
+			array(
+				'page' => 'BBB',
+				'addlevel' => '2',
+			),
+			'<div class="subpagelist">
+*** [[BBB/Sub|Sub]]
+</div>'
+		);
+	}
 
 }

--- a/tests/Component/WikitextSubPageListRendererTest.php
+++ b/tests/Component/WikitextSubPageListRendererTest.php
@@ -191,7 +191,7 @@ class WikitextSubPageListRendererTest extends \PHPUnit_Framework_TestCase {
 		) );
 	}
 	
-		public function testListForOnePageWithOneSub() {
+		public function testAddlevel() {
 		$this->assertCreatesList(
 			array(
 				'page' => 'BBB',


### PR DESCRIPTION
This is actually independent of issue #3.  This is actually to allow you to add extra bullets to the list so you can use this list inside of another list; it does not modify the list itself.  Works best if used with the "element=none" option so that this can nest inside of another list in wikitext.

So instead of 
* A
** 1
** 2
* B

You can use "addlevel=1" to get
** A
*** 1
*** 2
** B