### PR TITLE
Fix PageDeleteComplete hook calling getTitle() on ProperPageIdentity

### DIFF
--- a/src/Setup.php
+++ b/src/Setup.php
@@ -115,7 +115,7 @@ class Setup {
 		 */
 		$this->hookContainer->register( 'PageDeleteComplete', function( $page ) use ( $extension ) {
 			if ( $extension->getSettings()->get( Settings::AUTO_REFRESH ) ) {
-				$extension->getCacheInvalidator()->invalidateCaches( $page->getTitle() );
+				$extension->getCacheInvalidator()->invalidateCaches( Title::newFromPageIdentity( $page ) );
 			}
 		} );
 

--- a/tests/Unit/SubPageList/SetupTest.php
+++ b/tests/Unit/SubPageList/SetupTest.php
@@ -3,7 +3,12 @@
 namespace Tests\Unit\SubPageList;
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Page\ProperPageIdentity;
+use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
+use SubPageList\CacheInvalidator;
+use SubPageList\Extension;
+use SubPageList\Settings;
 use SubPageList\Setup;
 
 /**
@@ -30,6 +35,32 @@ class SetupTest extends TestCase {
 		$setup->run();
 
 		$this->assertTrue( $hookContainer->isRegistered( 'ParserFirstCallInit' ) );
+	}
+
+	public function testDeletedPageInvalidatesCache() {
+		$cacheInvalidator = $this->createMock( CacheInvalidator::class );
+		$cacheInvalidator->expects( $this->once() )
+			->method( 'invalidateCaches' )
+			->with( $this->callback( function ( Title $title ) {
+				return $title->getDBkey() === 'TestPage' && $title->getNamespace() === NS_MAIN;
+			} ) );
+
+		$extension = $this->createMock( Extension::class );
+		$extension->method( 'getSettings' )
+			->willReturn( new Settings( [ Settings::AUTO_REFRESH => true ] ) );
+		$extension->method( 'getCacheInvalidator' )
+			->willReturn( $cacheInvalidator );
+
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
+
+		$setup = new Setup( $extension, $hookContainer, __DIR__ . '/..' );
+		$setup->run();
+
+		$page = $this->createMock( ProperPageIdentity::class );
+		$page->method( 'getNamespace' )->willReturn( NS_MAIN );
+		$page->method( 'getDBkey' )->willReturn( 'TestPage' );
+
+		$hookContainer->run( 'PageDeleteComplete', [ $page, null, null, 0, null, null, 0 ] );
 	}
 
 	private function newExtension() {

--- a/tests/Unit/SubPageList/SetupTest.php
+++ b/tests/Unit/SubPageList/SetupTest.php
@@ -47,12 +47,13 @@ class SetupTest extends TestCase {
 				$registeredCallbacks[$name] = $callback;
 			} );
 
-		$cacheInvalidator = $this->createMock( CacheInvalidator::class );
-		$cacheInvalidator->expects( $this->once() )
-			->method( 'invalidateCaches' )
-			->with( $this->callback( function ( Title $title ) {
-				return $title->getDBkey() === 'TestPage' && $title->getNamespace() === NS_MAIN;
-			} ) );
+		$cacheInvalidator = new class implements CacheInvalidator {
+			public ?Title $invalidatedTitle = null;
+
+			public function invalidateCaches( Title $title ): void {
+				$this->invalidatedTitle = $title;
+			}
+		};
 
 		$extension = $this->createMock( Extension::class );
 		$extension->method( 'getSettings' )
@@ -69,6 +70,9 @@ class SetupTest extends TestCase {
 
 		$this->assertArrayHasKey( 'PageDeleteComplete', $registeredCallbacks );
 		$registeredCallbacks['PageDeleteComplete']( $page );
+
+		$this->assertSame( 'TestPage', $cacheInvalidator->invalidatedTitle->getDBkey() );
+		$this->assertSame( NS_MAIN, $cacheInvalidator->invalidatedTitle->getNamespace() );
 	}
 
 	private function newExtension() {

--- a/tests/Unit/SubPageList/SetupTest.php
+++ b/tests/Unit/SubPageList/SetupTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\SubPageList;
 
+use MediaWiki\HookContainer\HookContainer;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Page\ProperPageIdentity;
 use MediaWiki\Title\Title;
@@ -38,6 +39,14 @@ class SetupTest extends TestCase {
 	}
 
 	public function testDeletedPageInvalidatesCache() {
+		$registeredCallbacks = [];
+
+		$hookContainer = $this->createMock( HookContainer::class );
+		$hookContainer->method( 'register' )
+			->willReturnCallback( function ( $name, $callback ) use ( &$registeredCallbacks ) {
+				$registeredCallbacks[$name] = $callback;
+			} );
+
 		$cacheInvalidator = $this->createMock( CacheInvalidator::class );
 		$cacheInvalidator->expects( $this->once() )
 			->method( 'invalidateCaches' )
@@ -51,8 +60,6 @@ class SetupTest extends TestCase {
 		$extension->method( 'getCacheInvalidator' )
 			->willReturn( $cacheInvalidator );
 
-		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
-
 		$setup = new Setup( $extension, $hookContainer, __DIR__ . '/..' );
 		$setup->run();
 
@@ -60,7 +67,8 @@ class SetupTest extends TestCase {
 		$page->method( 'getNamespace' )->willReturn( NS_MAIN );
 		$page->method( 'getDBkey' )->willReturn( 'TestPage' );
 
-		$hookContainer->run( 'PageDeleteComplete', [ $page, null, null, 0, null, null, 0 ] );
+		$this->assertArrayHasKey( 'PageDeleteComplete', $registeredCallbacks );
+		$registeredCallbacks['PageDeleteComplete']( $page );
 	}
 
 	private function newExtension() {


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/SubPageList/issues/85

The `PageDeleteComplete` hook passes a `ProperPageIdentity` (concretely a
`PageStoreRecord`) as its first parameter, but the code called
`$page->getTitle()` which does not exist on that interface. This caused
a fatal error when deleting pages. Use `Title::newFromPageIdentity()`
instead, which correctly creates a Title from any PageIdentity.

The other two hooks (`PageSaveComplete` and `PageMoveComplete`) are unaffected —
`PageSaveComplete` receives a `WikiPage` which has `getTitle()`, and
`PageMoveComplete` already receives `Title` objects directly.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>