### PR TITLE
Fix stale README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ View the [release notes](doc/RELEASE-NOTES.md) for recent changes to SubPageList
 On Packagist: [![Latest Stable Version](https://poser.pugx.org/mediawiki/sub-page-list/version.png)](https://packagist.org/packages/mediawiki/sub-page-list)
 [![Download count](https://poser.pugx.org/mediawiki/sub-page-list/d/total.png)](https://packagist.org/packages/mediawiki/sub-page-list)
 
-* [Open issues](https://github.com/JeroenDeDauw/SubPageList/issues)
-* [Latest merged code changes](https://github.com/JeroenDeDauw/SubPageList/commits/master)
-* [Proposed code changes](https://github.com/JeroenDeDauw/SubPageList/pulls)
-* [SubPageList posts on Jeroens blog](http://www.bn2vs.com/blog/tag/subpagelist/)
+* [Open issues](https://github.com/ProfessionalWiki/SubPageList/issues)
+* [Latest merged code changes](https://github.com/ProfessionalWiki/SubPageList/commits/master)
+* [Proposed code changes](https://github.com/ProfessionalWiki/SubPageList/pulls)
+* [SubPageList posts on Jeroens blog](https://www.entropywins.wtf/blog/tag/subpagelist/)
 
 ## Further links
 


### PR DESCRIPTION
## Summary

* Point the issues / commits / pulls links at ``ProfessionalWiki/SubPageList`` (canonical) instead of ``JeroenDeDauw/SubPageList`` (currently redirects, but pointing at the canonical URL is cleaner and future-proof).
* Update Jeroen's blog tag link from ``bn2vs.com`` (cert expired, domain abandoned) to ``entropywins.wtf``, where the three SubPageList posts actually live.

No other content changes; just URL fixes.